### PR TITLE
Fix globals detection

### DIFF
--- a/lib/rules/no-deprecations.js
+++ b/lib/rules/no-deprecations.js
@@ -50,30 +50,15 @@ module.exports = {
         fixable: null,  // or "code" or "whitespace"
         schema: [
             // fill in your schema
-        ]
+        ],
+        messages: {
+            deprecatedGlobal: "The global property or function {{name}} was deprecated in Nextcloud {{version}}"
+        }
     },
 
     create: function (context) {
         return {
-            CallExpression: function (node) {
-                // Globals
-                if (global.hasOwnProperty(node.callee.name)) {
-                    context.report(node, "The global property or function " + node.callee.name + " was deprecated in Nextcloud " + global[node.callee.name]);
-                }
-            },
-            Identifier: function (node) {
-                // Globals
-                if (global.hasOwnProperty(node.name)) {
-                    context.report(node, "The global property or function " + node.name + " was deprecated in Nextcloud " + global[node.name]);
-                }
-            },
             MemberExpression: function (node) {
-                // Globals called with window.x
-                if (node.object.name === 'window'
-                    && global.hasOwnProperty(node.property.name)) {
-                    context.report(node, "The global property or function " + node.property.name + " was deprecated in Nextcloud " + oc[node.property.name]);
-                }
-
                 // OC.x
                 if (node.object.name === 'OC'
                     && oc.hasOwnProperty(node.property.name)) {
@@ -93,6 +78,35 @@ module.exports = {
                     const version = oc_sub[node.object.property.name][node.property.name]
                     context.report(node, "The property or function " + prop + " was deprecated in Nextcloud " + version);
                 }
+            },
+            Program() {
+                // Logic adapted from https://github.com/eslint/eslint/blob/master/lib/rules/no-restricted-globals.js
+                const scope = context.getScope();
+                const report = ref => {
+                    const node = ref.identifier;
+                    context.report({
+                        node,
+                        messageId: 'deprecatedGlobal',
+                        data: {
+                            name: node.name,
+                            version: global[node.name]
+                        },
+                    });
+                }
+
+                // Report variables declared elsewhere (ex: variables defined as "global" by eslint)
+                scope.variables.forEach(variable => {
+                    if (!variable.defs.length && global.hasOwnProperty(variable.name)) {
+                        variable.references.forEach(report);
+                    }
+                });
+
+                // Report variables not declared at all
+                scope.through.forEach(reference => {
+                    if (global.hasOwnProperty(reference.identifier.name)) {
+                        report(reference);
+                    }
+                });
             }
         };
     }

--- a/lib/rules/no-removed-apis.js
+++ b/lib/rules/no-removed-apis.js
@@ -40,24 +40,15 @@ module.exports = {
         fixable: null,  // or "code" or "whitespace"
         schema: [
             // fill in your schema
-        ]
+        ],
+        messages: {
+            removedGlobal: "The global property or function {{name}} was removed in Nextcloud {{version}}"
+        }
     },
 
     create: function (context) {
         return {
-            CallExpression: function (node) {
-                // Globals
-                if (global.hasOwnProperty(node.callee.name)) {
-                    context.report(node, "The global property or function " + node.callee.name + " was removed in Nextcloud " + global[node.callee.name]);
-                }
-            },
             MemberExpression: function (node) {
-                // Globals called with window.x
-                if (node.object.name === 'window'
-                    && global.hasOwnProperty(node.property.name)) {
-                    context.report(node, "The global property or function " + node.property.name + " was removed in Nextcloud " + oc[node.property.name]);
-                }
-
                 // OC.x
                 if (node.object.name === 'OC'
                     && oc.hasOwnProperty(node.property.name)) {
@@ -77,6 +68,35 @@ module.exports = {
                     const version = oc_sub[node.object.property.name][node.property.name]
                     context.report(node, "The property or function " + prop + " was removed in Nextcloud " + version);
                 }
+            },
+            Program() {
+                // Logic adapted from https://github.com/eslint/eslint/blob/master/lib/rules/no-restricted-globals.js
+                const scope = context.getScope();
+                const report = ref => {
+                    const node = ref.identifier;
+                    context.report({
+                        node,
+                        messageId: 'removedGlobal',
+                        data: {
+                            name: node.name,
+                            version: global[node.name]
+                        },
+                    });
+                }
+
+                // Report variables declared elsewhere (ex: variables defined as "global" by eslint)
+                scope.variables.forEach(variable => {
+                    if (!variable.defs.length && global.hasOwnProperty(variable.name)) {
+                        variable.references.forEach(report);
+                    }
+                });
+
+                // Report variables not declared at all
+                scope.through.forEach(reference => {
+                    if (global.hasOwnProperty(reference.identifier.name)) {
+                        report(reference);
+                    }
+                });
             }
         };
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "repository": "git+https://github.com/nextcloud/eslint-plugin.git",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha tests --recursive"
+    "test": "mocha tests --recursive",
+    "test:watch": "mocha tests --recursive --watch"
   },
   "dependencies": {
     "requireindex": "~1.2.0"

--- a/tests/lib/rules/no-deprecations.js
+++ b/tests/lib/rules/no-deprecations.js
@@ -21,11 +21,19 @@ var ruleTester = new RuleTester();
 ruleTester.run("no-deprecations", rule, {
 
     valid: [
-
-        // give me some code that won't trigger a warning
+        {
+            code: "var escapeHTML = require('escape-html'); var sanitized = escapeHTML('hello')",
+        }
     ],
 
     invalid: [
+        {
+            code: "var sanitized = escapeHTML('hello')",
+            errors: [{
+                message: "The global property or function escapeHTML was deprecated in Nextcloud 16.0.0",
+                type: "Identifier"
+            }]
+        },
         {
             code: "OC.getHost()",
             errors: [{

--- a/tests/lib/rules/no-removed-apis.js
+++ b/tests/lib/rules/no-removed-apis.js
@@ -21,8 +21,9 @@ var ruleTester = new RuleTester();
 ruleTester.run("no-removed-apis", rule, {
 
     valid: [
-
-        // give me some code that won't trigger a warning
+        {
+            code: "var fileDownloadPath = require('fileDownloadPath'); fileDownloadPath(123);"
+        }
     ],
 
     invalid: [
@@ -31,6 +32,13 @@ ruleTester.run("no-removed-apis", rule, {
             errors: [{
                 message: "The property or function OC.Util.isIE8 was removed in Nextcloud 15.0.0",
                 type: "MemberExpression"
+            }]
+        },
+        {
+            code: "fileDownloadPath()",
+            errors: [{
+                message: "The global property or function fileDownloadPath was removed in Nextcloud 15.0.0",
+                type: "Identifier"
             }]
         }
     ]


### PR DESCRIPTION
The previous logic was not correct in some cases. It just checked if certain symbols were used, but not if they were defined. Hence imported variables (that are actually fine) were wrongly reported as invalid.