### PR TITLE
fix: `OCA.Search` was removed in Nextcloud 20

### DIFF
--- a/lib/rules/no-removed-apis.js
+++ b/lib/rules/no-removed-apis.js
@@ -35,6 +35,11 @@ const oc_sub = {
     },
 }
 
+const oca = {
+    // ref: https://github.com/nextcloud/server/commit/6eced42b7a40f5b0ea0489244583219d0ee2e7af
+    Search: '20.0.0',
+}
+
 // TODO: handle OC.x.y.z like OC.Share.ShareConfigModel.areAvatarsEnabled()
 //       ref https://github.com/nextcloud/server/issues/11045
 
@@ -57,6 +62,12 @@ module.exports = {
     create: function (context) {
         return {
             MemberExpression: function (node) {
+                // OCA.x
+                if (node.object.name === 'OCA'
+                    && oca.hasOwnProperty(node.property.name)) {
+                    context.report(node, "The property or function OCA." + node.property.name + " was removed in Nextcloud " + oc[node.property.name]);
+                }
+
                 // OC.x
                 if (node.object.name === 'OC'
                     && oc.hasOwnProperty(node.property.name)) {


### PR DESCRIPTION
See commit: https://github.com/nextcloud/server/commit/6eced42b7a40f5b0ea0489244583219d0ee2e7af
